### PR TITLE
add variable for http_put_response_hop_limit

### DIFF
--- a/launch-template.tf
+++ b/launch-template.tf
@@ -93,7 +93,7 @@ resource "aws_launch_template" "default" {
   #     If any containers that you deploy to the node group use the Instance Metadata Service Version 2,
   #     then make sure to set the Metadata response hop limit to 2 in your launch template.
   metadata_options {
-    http_put_response_hop_limit = 2
+    http_put_response_hop_limit = var.launch_template_http_put_response_hop_limit
     # Despite being documented as "Optional", `http_endpoint` is required when `http_put_response_hop_limit` is set.
     # We set it to the default setting of "enabled".
     http_endpoint = "enabled"

--- a/launch-template.tf
+++ b/launch-template.tf
@@ -96,6 +96,7 @@ resource "aws_launch_template" "default" {
     http_put_response_hop_limit = var.launch_template_http_put_response_hop_limit
     # Despite being documented as "Optional", `http_endpoint` is required when `http_put_response_hop_limit` is set.
     # We set it to the default setting of "enabled".
+    http_tokens = var.launch_template_http_tokens
     http_endpoint = "enabled"
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -285,3 +285,8 @@ variable "launch_template_disk_encryption_kms_key_id" {
   description = "Custom KMS Key ID to encrypt EBS volumes on EC2 instances, applicable only if `launch_template_disk_encryption_enabled` is set to true"
 }
 
+variable "launch_template_http_put_response_hop_limit" {
+  type        = number
+  default     = 2
+  description = "The desired HTTP PUT response hop limit for instance metadata requests"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -290,3 +290,9 @@ variable "launch_template_http_put_response_hop_limit" {
   default     = 2
   description = "The desired HTTP PUT response hop limit for instance metadata requests"
 }
+
+variable "launch_template_http_tokens" {
+  type        = string
+  default     = "optional"
+  description = "Whether or not the metadata service requires session tokens"
+}


### PR DESCRIPTION
## what
Get http_put_response_hop_limit from variables 

## why
If we need to disable metadata API for pods without serviceaccount and network!=host we need to set http_put_response_hop_limit == 1.

## references
https://docs.aws.amazon.com/eks/latest/userguide/best-practices-security.html#restrict-ec2-credential-access
